### PR TITLE
[WIP]修复lint-md问题

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: yuque/lint-md
+      - image: fivezh/lint-md:cli2
     steps:
       - checkout
       - run: lint-md .


### PR DESCRIPTION
替换有问题的yuque/lint-md镜像问题，先使用自编译镜像

- yuque/lint-md在近期升级后，镜像有问题导致CI时无法找到lint-md命令
- 自编译fivezh/lint-md:cli，在官方基础上未做任何修改，只是修改了dockerfile重新编译、发布
- 已向yuque/lint-md官方提[issue](https://github.com/hustcc/lint-md/issues/50)，目前尚未回复

为保证CI正常运行，可先采用我编译的镜像版本