### PR TITLE
修复lint-md问题 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   lint:
     docker:
-      - image: yuque/lint-md
+      - image: fivezh/lint-md:cli
     steps:
       - checkout
       - run: lint-md .

--- a/2019/w31_go2draft-contracts.md
+++ b/2019/w31_go2draft-contracts.md
@@ -1974,7 +1974,7 @@ This section lists some of those ideas in the hopes that it will help
 to reduce repetitive discussion.
 The ideas are presented in the form of a FAQ.
 
-##### Why not use interfaces instead of contracts?
+##### Why not use interfaces instead of contracts
 
 _The interface method syntax is familiar._
 _Why introduce another way to write methods?_
@@ -2026,7 +2026,7 @@ with a single type parameter that lists only methods.
 But that should not mislead us into thinking that contracts are
 interfaces.
 
-##### Why not permit contracts to describe a type?
+##### Why not permit contracts to describe a type
 
 _In order to use operators contracts have to explicitly and tediously_
 _list types._
@@ -2039,7 +2039,7 @@ syntactic constructs, making contracts complicated and hard to read.
 The approach used in this design is simpler and relies on only a few
 new syntactic constructs and names.
 
-##### Why not put type parameters on packages?
+##### Why not put type parameters on packages
 
 We investigated this extensively.
 It becomes problematic when you want to write a `list` package, and
@@ -2053,7 +2053,7 @@ There is no particular reason to think that the uses of parameterized
 types will break down neatly into packages.
 Sometimes they will, sometimes they won't.
 
-##### Why not use the syntax `F<T>` like C++ and Java?
+##### Why not use the syntax `F<T>` like C++ and Java
 
 When parsing code within a function, such as `v := F<T>`, at the point
 of seeing the `<` it's ambiguous whether we are seeing a type
@@ -2061,7 +2061,7 @@ instantiation or an expression using the `<` operator.
 Resolving that requires effectively unbounded lookahead.
 In general we strive to keep the Go parser simple.
 
-##### Why not use the syntax `F[T]`?
+##### Why not use the syntax `F[T]`
 
 When parsing a type declaration `type A [T] int` it's ambiguous
 whether this is a parameterized type defined (uselessly) as `int` or
@@ -2087,12 +2087,12 @@ More generally, we felt that the square brackets were too intrusive on
 the page and that parentheses were more Go like.
 We will reevaluate this decision as we gain more experience.
 
-##### Why not use `F«T»`?
+##### Why not use `F«T»`
 
 We considered it but we couldn't bring ourselves to require
 non-ASCII.
 
-##### Why not define contracts in a standard package?
+##### Why not define contracts in a standard package
 
 _Instead of writing out contracts, use names like_
 _`contracts.Arithmetic` and `contracts.Comparable`._

--- a/2019/w35_go_compiler_intrinsics.md
+++ b/2019/w35_go_compiler_intrinsics.md
@@ -68,7 +68,7 @@ BenchmarkAddAsm-8     606165915         1.93 ns/op
 > 译者注：Go 原生的方式，性能优于汇编方式，这也是本文所关注的 Go 内建函数的优化。
 
 多年来，已经有多种提案来支持内联汇编的语法，比如类似与 gcc 的 `asm(...)` 指令。但没有任何一个提案被 Go 团队接受。相反，Go 添加了一种内建函数 *intrinsic functions* 。
-> 注1：内建函数 可能不是他们的正式名称，但是这个词在编译器及其测试中是很常用的。
+> 注 1：内建函数 可能不是他们的正式名称，但是这个词在编译器及其测试中是很常用的。
 > 
 > 译者注：参见维基百科[Intrinsic function](https://en.wikipedia.org/wiki/Intrinsic_function)
 
@@ -89,7 +89,7 @@ BenchmarkAddAsm-8     606165915         1.93 ns/op
 
 要了解这有多么有效，我们可以比较三种不同的计数实现。 第一个是 Kernighan 在《The C Programming Language 2nd Ed, 1998》书中提到的算法。
 
-> 注2：Kernighan 《The C Programming Language 2nd Ed, 1998》，C语言Bible
+> 注 2：Kernighan 《The C Programming Language 2nd Ed, 1998》，C 语言 Bible
 
 ```go
 func kernighan(x uint64) int {
@@ -153,7 +153,7 @@ func BenchmarkMathBitsOnesCount64(b *testing.B) {
 
 为了保持公平，我们在为每个被测函数提供相同的输入：从零到 `b.N` 的整数序列。这对于 Kernighan 的方法更为公平，因为它的运行时间随着入参的位数而逐渐增加。
 
-> 注3：作为加分小作业，可以尝试将 `0xdeadbeefdeadbeef` 传递给每个被测试的函数，看看运行结果如何。
+> 注 3：作为加分小作业，可以尝试将 `0xdeadbeefdeadbeef` 传递给每个被测试的函数，看看运行结果如何。
 
 来看下测试结果：`go test -bench=. -run=none`
 
@@ -168,7 +168,6 @@ BenchmarkMathBitsOnesCount64-8  1000000000  0.565 ns/op
 ```plain
 % go test -c
 % go tool objdump -s MathBitsOnesCount popcnt-intrinsic.test
-<<<<<<< HEAD
 TEXT examples/popcnt-intrinsic.BenchmarkMathBitsOnesCount64(SB) 
 /examples/popcnt-intrinsic/popcnt_test.go
    popcnt_test.go:45     0x10f8610    65488b0c2530000000  MOVQ GS:0x30, CX
@@ -207,43 +206,6 @@ TEXT examples/popcnt-intrinsic.BenchmarkMathBitsOnesCount64(SB)
    :-1                   0x10f868e    cc                  INT $0x3
    :-1                   0x10f868f    cc                  INT $0x3 
  ```
-=======
-TEXT examples/popcnt-intrinsic.BenchmarkMathBitsOnesCount64(SB) /examples/popcnt-intrinsic/popcnt_test.go
-   popcnt_test.go:45     0x10f8610               65488b0c2530000000      MOVQ GS:0x30, CX
-   popcnt_test.go:45     0x10f8619               483b6110                CMPQ 0x10(CX), SP
-   popcnt_test.go:45     0x10f861d               7668                    JBE 0x10f8687
-   popcnt_test.go:45     0x10f861f               4883ec20                SUBQ $0x20, SP
-   popcnt_test.go:45     0x10f8623               48896c2418              MOVQ BP, 0x18(SP)
-   popcnt_test.go:45     0x10f8628               488d6c2418              LEAQ 0x18(SP), BP
-   popcnt_test.go:47     0x10f862d               488b442428              MOVQ 0x28(SP), AX
-   popcnt_test.go:47     0x10f8632               31c9                    XORL CX, CX
-   popcnt_test.go:47     0x10f8634               31d2                    XORL DX, DX
-   popcnt_test.go:47     0x10f8636               eb03                    JMP 0x10f863b
-   popcnt_test.go:47     0x10f8638               48ffc1                  INCQ CX
-   popcnt_test.go:47     0x10f863b               48398808010000          CMPQ CX, 0x108(AX)
-   popcnt_test.go:47     0x10f8642               7e32                    JLE 0x10f8676
-   popcnt_test.go:48     0x10f8644               803d29d5150000          CMPB $0x0, runtime.x86HasPOPCNT(SB)
-   popcnt_test.go:48     0x10f864b               740a                    JE 0x10f8657
-   popcnt_test.go:48     0x10f864d               4831d2                  XORQ DX, DX
-   popcnt_test.go:48     0x10f8650               f3480fb8d1              POPCNT CX, DX // math/bits.OnesCount64
-   popcnt_test.go:48     0x10f8655               ebe1                    JMP 0x10f8638
-   popcnt_test.go:47     0x10f8657               48894c2410              MOVQ CX, 0x10(SP)
-   popcnt_test.go:48     0x10f865c               48890c24                MOVQ CX, 0(SP)
-   popcnt_test.go:48     0x10f8660               e87b28f8ff              CALL math/bits.OnesCount64(SB)
-   popcnt_test.go:48     0x10f8665               488b542408              MOVQ 0x8(SP), DX
-   popcnt_test.go:47     0x10f866a               488b442428              MOVQ 0x28(SP), AX
-   popcnt_test.go:47     0x10f866f               488b4c2410              MOVQ 0x10(SP), CX
-   popcnt_test.go:48     0x10f8674               ebc2                    JMP 0x10f8638
-   popcnt_test.go:50     0x10f8676               48891563d51500          MOVQ DX, examples/popcnt-intrinsic.Result(SB)
-   popcnt_test.go:51     0x10f867d               488b6c2418              MOVQ 0x18(SP), BP
-   popcnt_test.go:51     0x10f8682               4883c420                ADDQ $0x20, SP
-   popcnt_test.go:51     0x10f8686               c3                      RET
-   popcnt_test.go:45     0x10f8687               e884eef5ff              CALL runtime.morestack_noctxt(SB)
-   popcnt_test.go:45     0x10f868c               eb82                    JMP examples/popcnt-intrinsic.BenchmarkMathBitsOnesCount64(SB)
-   :-1                   0x10f868e               cc                      INT $0x3
-   :-1                   0x10f868f               cc                     INT $0x3 
-```
->>>>>>> b2c662d75381ee01ba565ec491397bf4de703f14
 
 这里输出了很多内容，但关键的内容是第 48 行（取自 `_test.go` 文件的源代码），程序确实使用了我们期望的 x86 `POPCNT` 指令。事实证明这比操作位运算更快。
 

--- a/2019/w35_go_compiler_intrinsics.md
+++ b/2019/w35_go_compiler_intrinsics.md
@@ -150,40 +150,43 @@ The winner by nearly 4x is `math/bits.OnesCount64`, but is this really using a h
 ```plain
 % go test -c
 % go tool objdump -s MathBitsOnesCount popcnt-intrinsic.test
-TEXT examples/popcnt-intrinsic.BenchmarkMathBitsOnesCount64(SB) /examples/popcnt-intrinsic/popcnt_test.go
-   popcnt_test.go:45     0x10f8610               65488b0c2530000000      MOVQ GS:0x30, CX
-   popcnt_test.go:45     0x10f8619               483b6110                CMPQ 0x10(CX), SP
-   popcnt_test.go:45     0x10f861d               7668                    JBE 0x10f8687
-   popcnt_test.go:45     0x10f861f               4883ec20                SUBQ $0x20, SP
-   popcnt_test.go:45     0x10f8623               48896c2418              MOVQ BP, 0x18(SP)
-   popcnt_test.go:45     0x10f8628               488d6c2418              LEAQ 0x18(SP), BP
-   popcnt_test.go:47     0x10f862d               488b442428              MOVQ 0x28(SP), AX
-   popcnt_test.go:47     0x10f8632               31c9                    XORL CX, CX
-   popcnt_test.go:47     0x10f8634               31d2                    XORL DX, DX
-   popcnt_test.go:47     0x10f8636               eb03                    JMP 0x10f863b
-   popcnt_test.go:47     0x10f8638               48ffc1                  INCQ CX
-   popcnt_test.go:47     0x10f863b               48398808010000          CMPQ CX, 0x108(AX)
-   popcnt_test.go:47     0x10f8642               7e32                    JLE 0x10f8676
-   popcnt_test.go:48     0x10f8644               803d29d5150000          CMPB $0x0, runtime.x86HasPOPCNT(SB)
-   popcnt_test.go:48     0x10f864b               740a                    JE 0x10f8657
-   popcnt_test.go:48     0x10f864d               4831d2                  XORQ DX, DX
-   popcnt_test.go:48     0x10f8650               f3480fb8d1              POPCNT CX, DX // math/bits.OnesCount64
-   popcnt_test.go:48     0x10f8655               ebe1                    JMP 0x10f8638
-   popcnt_test.go:47     0x10f8657               48894c2410              MOVQ CX, 0x10(SP)
-   popcnt_test.go:48     0x10f865c               48890c24                MOVQ CX, 0(SP)
-   popcnt_test.go:48     0x10f8660               e87b28f8ff              CALL math/bits.OnesCount64(SB)
-   popcnt_test.go:48     0x10f8665               488b542408              MOVQ 0x8(SP), DX
-   popcnt_test.go:47     0x10f866a               488b442428              MOVQ 0x28(SP), AX
-   popcnt_test.go:47     0x10f866f               488b4c2410              MOVQ 0x10(SP), CX
-   popcnt_test.go:48     0x10f8674               ebc2                    JMP 0x10f8638
-   popcnt_test.go:50     0x10f8676               48891563d51500          MOVQ DX, examples/popcnt-intrinsic.Result(SB)
-   popcnt_test.go:51     0x10f867d               488b6c2418              MOVQ 0x18(SP), BP
-   popcnt_test.go:51     0x10f8682               4883c420                ADDQ $0x20, SP
-   popcnt_test.go:51     0x10f8686               c3                      RET
-   popcnt_test.go:45     0x10f8687               e884eef5ff              CALL runtime.morestack_noctxt(SB)
-   popcnt_test.go:45     0x10f868c               eb82                    JMP examples/popcnt-intrinsic.BenchmarkMathBitsOnesCount64(SB)
-   :-1                   0x10f868e               cc                      INT $0x3
-   :-1                   0x10f868f               cc                     INT $0x3 
+TEXT examples/popcnt-intrinsic.BenchmarkMathBitsOnesCount64(SB) 
+/examples/popcnt-intrinsic/popcnt_test.go
+   popcnt_test.go:45     0x10f8610    65488b0c2530000000  MOVQ GS:0x30, CX
+   popcnt_test.go:45     0x10f8619    483b6110            CMPQ 0x10(CX), SP
+   popcnt_test.go:45     0x10f861d    7668                JBE 0x10f8687
+   popcnt_test.go:45     0x10f861f    4883ec20            SUBQ $0x20, SP
+   popcnt_test.go:45     0x10f8623    48896c2418          MOVQ BP, 0x18(SP)
+   popcnt_test.go:45     0x10f8628    488d6c2418          LEAQ 0x18(SP), BP
+   popcnt_test.go:47     0x10f862d    488b442428          MOVQ 0x28(SP), AX
+   popcnt_test.go:47     0x10f8632    31c9                XORL CX, CX
+   popcnt_test.go:47     0x10f8634    31d2                XORL DX, DX
+   popcnt_test.go:47     0x10f8636    eb03                JMP 0x10f863b
+   popcnt_test.go:47     0x10f8638    48ffc1              INCQ CX
+   popcnt_test.go:47     0x10f863b    48398808010000      CMPQ CX, 0x108(AX)
+   popcnt_test.go:47     0x10f8642    7e32                JLE 0x10f8676
+   popcnt_test.go:48     0x10f8644    803d29d5150000      CMPB $0x0, runtime.x86HasPOPCNT(SB)
+   popcnt_test.go:48     0x10f864b    740a                JE 0x10f8657
+   popcnt_test.go:48     0x10f864d    4831d2              XORQ DX, DX
+   popcnt_test.go:48     0x10f8650    f3480fb8d1          POPCNT CX, DX // math/bits.OnesCount64
+   popcnt_test.go:48     0x10f8655    ebe1                JMP 0x10f8638
+   popcnt_test.go:47     0x10f8657    48894c2410          MOVQ CX, 0x10(SP)
+   popcnt_test.go:48     0x10f865c    48890c24            MOVQ CX, 0(SP)
+   popcnt_test.go:48     0x10f8660    e87b28f8ff          CALL math/bits.OnesCount64(SB)
+   popcnt_test.go:48     0x10f8665    488b542408          MOVQ 0x8(SP), DX
+   popcnt_test.go:47     0x10f866a    488b442428          MOVQ 0x28(SP), AX
+   popcnt_test.go:47     0x10f866f    488b4c2410          MOVQ 0x10(SP), CX
+   popcnt_test.go:48     0x10f8674    ebc2                JMP 0x10f8638
+   popcnt_test.go:50     0x10f8676    48891563d51500      MOVQ DX, examples/
+   popcnt-intrinsic.Result(SB)
+   popcnt_test.go:51     0x10f867d    488b6c2418          MOVQ 0x18(SP), BP
+   popcnt_test.go:51     0x10f8682    4883c420            ADDQ $0x20, SP
+   popcnt_test.go:51     0x10f8686    c3                  RET
+   popcnt_test.go:45     0x10f8687    e884eef5ff          CALL runtime.morestack_noctxt(SB)
+   popcnt_test.go:45     0x10f868c    eb82                JMP examples/
+   popcnt-intrinsic.BenchmarkMathBitsOnesCount64(SB)
+   :-1                   0x10f868e    cc                  INT $0x3
+   :-1                   0x10f868f    cc                  INT $0x3 
  ```
 
 There’s quite a bit going on here, but the key take away is on line 48 (taken from the source code of the `_test.go` file) the program is using the x86 `POPCNT` instruction as we hoped. This turns out to be faster than bit twiddling.
@@ -236,16 +239,16 @@ You’d be forgiven for thinking this would have a lot of overhead. However, bec
 
 ```plain
 TEXT main.f(SB) examples/counter/counter.go
-   counter.go:23         0x10512e0               90                      NOPL
-   counter.go:29         0x10512e1               b801000000              MOVL $0x1, AX
-   counter.go:13         0x10512e6               488d0d0bca0800          LEAQ main.c(SB), CX
-   counter.go:13         0x10512ed               f0480fc101              LOCK XADDQ AX, 0(CX) // c.inc
-   counter.go:24         0x10512f2               90                      NOPL
-   counter.go:10         0x10512f3               488b05fec90800          MOVQ main.c(SB), AX // c.get
-   counter.go:25         0x10512fa               90                      NOPL
-   counter.go:16         0x10512fb               31c0                    XORL AX, AX
-   counter.go:16         0x10512fd               488701                  XCHGQ AX, 0(CX) // c.reset
-   counter.go:16         0x1051300               c3                      RET 
+   counter.go:23   0x10512e0   90                      NOPL
+   counter.go:29   0x10512e1   b801000000              MOVL $0x1, AX
+   counter.go:13   0x10512e6   488d0d0bca0800          LEAQ main.c(SB), CX
+   counter.go:13   0x10512ed   f0480fc101              LOCK XADDQ AX, 0(CX) // c.inc
+   counter.go:24   0x10512f2   90                      NOPL
+   counter.go:10   0x10512f3   488b05fec90800          MOVQ main.c(SB), AX // c.get
+   counter.go:25   0x10512fa   90                      NOPL
+   counter.go:16   0x10512fb   31c0                    XORL AX, AX
+   counter.go:16   0x10512fd   488701                  XCHGQ AX, 0(CX) // c.reset
+   counter.go:16   0x1051300               c3                      RET 
 ```
 
 By way of explanation. The first operation, `counter.go:13` is `c.inc` a `LOCK`ed `XADDQ`, which on x86 is an atomic increment. The second, `counter.go:10` is `c.get` which on x86, due to its strong memory consistency model, is a regular load from memory. The final operation, `counter.go:16`, `c.reset` is an atomic exchange of the address in `CX` with `AX` which was zeroed on the previous line. This puts the value in `AX`, zero, into the address stored in `CX`. The value previously stored at `(CX)` is discarded.


### PR DESCRIPTION
替换有问题的yuque/lint-md镜像问题，先使用自编译镜像

- yuque/lint-md在近期升级后，镜像有问题导致CI时无法找到lint-md命令
- 自编译fivezh/lint-md:cli，在官方基础上未做任何修改，只是修改了dockerfile重新编译、发布
- 已向yuque/lint-md官方提[issue](https://github.com/hustcc/lint-md/issues/50)，目前尚未回复

为保证CI正常运行，可先采用我编译的镜像版本


**PS**：目前发现circleci中失败job，仅展示状态，不展示详细失败原因，rebuild后可以查看详细原因，原因未知。
更新：从官方论坛看，也有[其他用户反馈此问题](https://discuss.circleci.com/t/step-logs-disappear-after-build-ends/32290/3)，看样子是circleci的bug导致。

实时查看job执行或rebuild后立即打开，可查看Job失败详情：
![image](https://user-images.githubusercontent.com/1311319/64490659-d2c92800-d291-11e9-8a1b-859b149cbc4b.png)

重新刷新页面或Job完成后进入详情，无法查看Job失败详情：一脸懵逼 😞 
![image](https://user-images.githubusercontent.com/1311319/64490667-f2605080-d291-11e9-9376-7694727502f7.png)
